### PR TITLE
Add contents: write.

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -8,6 +8,7 @@ permissions:
   # This is necessary for AWS credentials. See:
   # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
   id-token: write
+  contents: write
 
 jobs:
 


### PR DESCRIPTION
I've overseen a sentence in the document, but
> If you specify the access for any of these scopes, all of those that are not specified are set to none.

which prohibits the action to create a tag.