### PR TITLE
Fix the docker command parameter.

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -60,18 +60,18 @@ jobs:
     - name: Build, tag, and push dispatcher to Amazon ECR
       uses: docker/build-push-action@v5
       with:
-        context: ./build/dispatcher
+        file: ./build/dispatcher/Dockerfile
         push: true
         tags: public.ecr.aws/v8n3t7y5/llm-operator/job-manager:dispatcher-${{ needs.update-tag.outputs.new_tag }}
     - name: Build, tag, and push server to Amazon ECR
       uses: docker/build-push-action@v5
       with:
-        context: ./build/server
+        file: ./build/server/Dockerfile
         push: true
         tags: public.ecr.aws/v8n3t7y5/llm-operator/job-manager:server-${{ needs.update-tag.outputs.new_tag }}
     - name: Build, tag, and push fine-tuning to Amazon ECR
       uses: docker/build-push-action@v5
       with:
-        context: ./build/experiments/fine-tuning
+        file: ./build/experiments/fine-tuning/Dockerfile
         push: true
         tags: public.ecr.aws/v8n3t7y5/llm-operator/job-manager:fine-tuning-${{ needs.update-tag.outputs.new_tag }}


### PR DESCRIPTION
Dockerfiles here is supposed to be the top-directory context (i.e. passing `.` as the last parameter) while the Dockerfile is supplied through --file flag. The current action parameters are different, and so COPY command in the file does not work as expected.