### PR TITLE
Fix ecr-login action parameters.

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -44,7 +44,7 @@ jobs:
     - update-tag
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Docker BUIldx
+    - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -55,8 +55,7 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registries: '803339316953'
-        mask-password: "true"
+        registry-type: public
     - name: Build, tag, and push dispatcher to Amazon ECR
       uses: docker/build-push-action@v5
       with:


### PR DESCRIPTION
Reviewed readme doc https://github.com/aws-actions/amazon-ecr-login?tab=readme-ov-file#ecr-public, but seemingly the current parameter isn't very correct. For public-ECR, `registry-type: public` should be supplied. mask-password seems not necessary.