### PR TITLE
Fix a typo.

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Set up Helm
       uses: Azure/setup-helm@v4
     - name: Fetch index.yaml
-      run: curl -o index.yaml http://llm-operator-charts.s3-website-us-west-2.amazonaws.com/charts/index.yaml
+      run: curl -o index.yaml http://llm-operator-charts.s3-website-us-west-2.amazonaws.com/index.yaml
     - name: Set up charts directory
       run: mkdir charts
     - name: build dispatcher helm chart


### PR DESCRIPTION
It was my misunderstanding, `charts/` path is not necessary actually.  We can simply place those files and index.yaml file directly on the toplevel of the s3 bucket.

Other commands work that way but getting the old index.yaml file part was wrong.