### PR TITLE
Skip build and push of fine-tuning as post-merge.

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -68,12 +68,6 @@ jobs:
         file: ./build/server/Dockerfile
         push: true
         tags: public.ecr.aws/v8n3t7y5/llm-operator/job-manager:server-${{ needs.update-tag.outputs.new_tag }}
-    - name: Build, tag, and push fine-tuning to Amazon ECR
-      uses: docker/build-push-action@v5
-      with:
-        context: ./build/experiments/fine-tuning
-        push: true
-        tags: public.ecr.aws/v8n3t7y5/llm-operator/job-manager:fine-tuning-${{ needs.update-tag.outputs.new_tag }}
 
   publish-helm-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-build-and-push-fine-tuning.yml
+++ b/.github/workflows/manual-build-and-push-fine-tuning.yml
@@ -1,0 +1,38 @@
+name: manual-build-and-push-fine-tuning
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag'
+        required: true
+        type: string
+
+permissions:
+  # This is necessary for AWS credentials. See:
+  # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+  id-token: write
+  contents: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::803339316953:role/github-actions-ecr-push-llm-operators
+        aws-region: us-east-1
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registry-type: public
+    - name: Build, tag, and push fine-tuning to Amazon ECR
+      uses: docker/build-push-action@v5
+      with:
+        context: ./build/experiments/fine-tuning
+        push: true
+        tags: public.ecr.aws/v8n3t7y5/llm-operator/job-manager:fine-tuning-${{ inputs.tag }}


### PR DESCRIPTION
I think the fine-tuning docker image is not under active development, rather a sample one.  I don't think we should rebiuld the new docker image for every update.

My current observation is that a post-merge run takes ~15 mins, and ~13 mins is spent for fine-tuning, I don't think it's worth doing as a post-merge action, at least for now.