### PR TITLE
Add arm64 support and latest tag.

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -61,13 +61,19 @@ jobs:
       with:
         file: ./build/dispatcher/Dockerfile
         push: true
-        tags: public.ecr.aws/v8n3t7y5/llm-operator/job-manager-dispatcher:${{ needs.update-tag.outputs.new_tag }}
+        platforms: linux/amd64,linux/arm64
+        tags: |
+          public.ecr.aws/v8n3t7y5/llm-operator/job-manager-dispatcher:${{ needs.update-tag.outputs.new_tag }}
+          public.ecr.aws/v8n3t7y5/llm-operator/job-manager-dispatcher:latest
     - name: Build, tag, and push server to Amazon ECR
       uses: docker/build-push-action@v5
       with:
         file: ./build/server/Dockerfile
         push: true
-        tags: public.ecr.aws/v8n3t7y5/llm-operator/job-manager-server:${{ needs.update-tag.outputs.new_tag }}
+        platforms: linux/amd64,linux/arm64
+        tags: |
+          public.ecr.aws/v8n3t7y5/llm-operator/job-manager-server:${{ needs.update-tag.outputs.new_tag }}
+          public.ecr.aws/v8n3t7y5/llm-operator/job-manager-server:latest
 
   publish-helm-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-build-and-push-fine-tuning.yml
+++ b/.github/workflows/manual-build-and-push-fine-tuning.yml
@@ -40,4 +40,7 @@ jobs:
       with:
         context: ./build/experiments/${{ inputs.image }}
         push: true
-        tags: public.ecr.aws/v8n3t7y5/llm-operator/${{ inputs.image }}:${{ inputs.tag }}
+        platforms: linux/amd64,linux/arm64
+        tags: |
+          public.ecr.aws/v8n3t7y5/llm-operator/${{ inputs.image }}:${{ inputs.tag }}
+          public.ecr.aws/v8n3t7y5/llm-operator/${{ inputs.image }}:latest


### PR DESCRIPTION
ARM64 is helpful when testing on Mac. latest tag can be helpful especially for fine-tuning job image.