### PR TITLE
Add checksum annotation for config changes.

### DIFF
--- a/deployments/dispatcher/templates/deployment.yaml
+++ b/deployments/dispatcher/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         {{- include "job-manager-dispatcher.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ sha256sum (toJson .Values) }}
     spec:
       serviceAccountName: {{ include "job-manager-dispatcher.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
This is for the case that a helm update changes some config changes but not the docker image of the pod. In that case normally the pod will not restart as pod template does not change, but the we want to restart as the config change may be significant.

This adds an annotation for the checksum of values.  That way, whatever changes some values, it would change the pod template and so pods will be restarted.

Some values may not cause config changes but other changes, but such over-restarting wouldn't be a huge issues usually.