### PR TITLE
Use the same namespace as llm-operator for job namespace by default

### DIFF
--- a/deployments/dispatcher/templates/role.yaml
+++ b/deployments/dispatcher/templates/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "job-manager-dispatcher.fullname" . }}
-  namespace: {{ .Values.jobNamespace }}
+  namespace: {{ .Values.jobNamespace | default .Release.Namespace | quote }}
   labels:
     {{- include "job-manager-dispatcher.labels" . | nindent 4 }}
 rules:

--- a/deployments/dispatcher/templates/rolebinding.yaml
+++ b/deployments/dispatcher/templates/rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "job-manager-dispatcher.fullname" . }}
-  namespace: {{ .Values.jobNamespace }}
+  namespace: {{ .Values.jobNamespace | default .Release.Namespace | quote }}
   labels:
     {{- include "job-manager-dispatcher.labels" . | nindent 4 }}
 subjects:

--- a/deployments/dispatcher/values.yaml
+++ b/deployments/dispatcher/values.yaml
@@ -21,7 +21,7 @@ global:
     secretAccessKeyKey:
 
 jobPollingInterval: 10s
-jobNamespace: default
+jobNamespace:
 job:
   image: public.ecr.aws/v8n3t7y5/llm-operator/fine-tuning
   version:

--- a/deployments/server/templates/role.yaml
+++ b/deployments/server/templates/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "job-manager-server.fullname" . }}-grpc
-  namespace: {{ .Values.jobNamespace }}
+  namespace: {{ .Values.jobNamespace | default .Release.Namespace | quote }}
   labels:
     {{- include "job-manager-server.labels" . | nindent 4 }}
 rules:

--- a/deployments/server/templates/rolebinding.yaml
+++ b/deployments/server/templates/rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "job-manager-server.fullname" . }}
-  namespace: {{ .Values.jobNamespace }}
+  namespace: {{ .Values.jobNamespace | default .Release.Namespace | quote }}
   labels:
     {{- include "job-manager-server.labels" . | nindent 4 }}
 subjects:

--- a/deployments/server/values.yaml
+++ b/deployments/server/values.yaml
@@ -27,7 +27,7 @@ modelManagerInternalServerAddr: llm-operator-model-manager-server-internal-grpc:
 database:
   database: job_manager
 
-jobNamespace: default
+jobNamespace:
 
 debug:
   kubeconfigPath:


### PR DESCRIPTION
To simplify the default installation configuration.