### PR TITLE
Implement project-level visibility

### DIFF
--- a/common/pkg/store/job.go
+++ b/common/pkg/store/job.go
@@ -40,7 +40,7 @@ type Job struct {
 	TenantID string   `gorm:"index:idx_job_state_tenant_id"`
 
 	OrganizationID      string
-	ProjectID           string
+	ProjectID           string `gorm:"index:idx_job_project_id"`
 	KubernetesNamespace string
 
 	// OutputModelID is the ID of a generated model.
@@ -92,10 +92,10 @@ func (s *S) GetJobByJobID(jobID string) (*Job, error) {
 	return &job, nil
 }
 
-// GetJobByJobIDAndTenantID gets a job by its job ID and tenant ID.
-func (s *S) GetJobByJobIDAndTenantID(jobID, tenantID string) (*Job, error) {
+// GetJobByJobIDAndProjectID gets a job by its job ID and tenant ID.
+func (s *S) GetJobByJobIDAndProjectID(jobID, projectID string) (*Job, error) {
 	var job Job
-	if err := s.db.Where("job_id = ? AND tenant_id = ?", jobID, tenantID).Take(&job).Error; err != nil {
+	if err := s.db.Where("job_id = ? AND project_id = ?", jobID, projectID).Take(&job).Error; err != nil {
 		return nil, err
 	}
 	return &job, nil
@@ -128,10 +128,10 @@ func (s *S) ListJobsByTenantID(tenantID string) ([]*Job, error) {
 	return jobs, nil
 }
 
-// ListJobsByTenantIDWithPagination finds jobs with pagination. Jobs are returned with a descending order of ID.
-func (s *S) ListJobsByTenantIDWithPagination(tenantID string, afterID uint, limit int) ([]*Job, bool, error) {
+// ListJobsByProjectIDWithPagination finds jobs with pagination. Jobs are returned with a descending order of ID.
+func (s *S) ListJobsByProjectIDWithPagination(projectID string, afterID uint, limit int) ([]*Job, bool, error) {
 	var jobs []*Job
-	q := s.db.Where("tenant_id = ?", tenantID)
+	q := s.db.Where("project_id = ?", projectID)
 	if afterID > 0 {
 		q = q.Where("id < ?", afterID)
 	}

--- a/common/pkg/store/job_test.go
+++ b/common/pkg/store/job_test.go
@@ -18,9 +18,9 @@ func TestCreateAndGetJob(t *testing.T) {
 	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 
 	job := &Job{
-		JobID:    "job0",
-		State:    JobStateQueued,
-		TenantID: "tid0",
+		JobID:     "job0",
+		State:     JobStateQueued,
+		ProjectID: "pid0",
 	}
 	err = st.CreateJob(job)
 	assert.NoError(t, err)
@@ -29,12 +29,12 @@ func TestCreateAndGetJob(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, job.JobID, got.JobID)
 
-	got, err = st.GetJobByJobIDAndTenantID("job0", "tid0")
+	got, err = st.GetJobByJobIDAndProjectID("job0", "pid0")
 	assert.NoError(t, err)
 	assert.Equal(t, job.JobID, got.JobID)
 
 	// Different tenant.
-	_, err = st.GetJobByJobIDAndTenantID("job0", "tid1")
+	_, err = st.GetJobByJobIDAndProjectID("job0", "pid1")
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 }
@@ -88,21 +88,21 @@ func TestCreateAndListJobs(t *testing.T) {
 	assert.Equal(t, jobs[1].JobID, got[1].JobID)
 }
 
-func TestListJobsByTenantIDWithPagination(t *testing.T) {
+func TestListJobsByProjectIDWithPagination(t *testing.T) {
 	st, teardown := NewTest(t)
 	defer teardown()
 
 	for i := 0; i < 10; i++ {
 		job := &Job{
-			JobID:    fmt.Sprintf("job%d", i),
-			State:    JobStateQueued,
-			TenantID: "tid0",
+			JobID:     fmt.Sprintf("job%d", i),
+			State:     JobStateQueued,
+			ProjectID: "pid0",
 		}
 		err := st.CreateJob(job)
 		assert.NoError(t, err)
 	}
 
-	got, hasMore, err := st.ListJobsByTenantIDWithPagination("tid0", 0, 5)
+	got, hasMore, err := st.ListJobsByProjectIDWithPagination("pid0", 0, 5)
 	assert.NoError(t, err)
 	assert.True(t, hasMore)
 	assert.Len(t, got, 5)
@@ -111,7 +111,7 @@ func TestListJobsByTenantIDWithPagination(t *testing.T) {
 		assert.Equal(t, want[i], job.JobID)
 	}
 
-	got, hasMore, err = st.ListJobsByTenantIDWithPagination("tid0", got[4].ID, 2)
+	got, hasMore, err = st.ListJobsByProjectIDWithPagination("pid0", got[4].ID, 2)
 	assert.NoError(t, err)
 	assert.True(t, hasMore)
 	assert.Len(t, got, 2)
@@ -120,7 +120,7 @@ func TestListJobsByTenantIDWithPagination(t *testing.T) {
 		assert.Equal(t, want[i], job.JobID)
 	}
 
-	got, hasMore, err = st.ListJobsByTenantIDWithPagination("tid0", got[1].ID, 3)
+	got, hasMore, err = st.ListJobsByProjectIDWithPagination("pid0", got[1].ID, 3)
 	assert.NoError(t, err)
 	assert.False(t, hasMore)
 	assert.Len(t, got, 3)

--- a/server/internal/server/jobs_test.go
+++ b/server/internal/server/jobs_test.go
@@ -121,9 +121,10 @@ func TestListJobs(t *testing.T) {
 		msg, err := proto.Marshal(jobProto)
 		assert.NoError(t, err)
 		job := &store.Job{
-			JobID:    jobProto.Id,
-			Message:  msg,
-			TenantID: fakeTenantID,
+			JobID:     jobProto.Id,
+			Message:   msg,
+			TenantID:  fakeTenantID,
+			ProjectID: defaultProjectID,
 		}
 		err = st.CreateJob(job)
 		assert.NoError(t, err)
@@ -164,7 +165,12 @@ func TestGetJob(t *testing.T) {
 	st, tearDown := store.NewTest(t)
 	defer tearDown()
 
-	err := st.CreateJob(&store.Job{JobID: jobID, TenantID: fakeTenantID, State: store.JobStateQueued})
+	err := st.CreateJob(&store.Job{
+		JobID:     jobID,
+		TenantID:  fakeTenantID,
+		ProjectID: defaultProjectID,
+		State:     store.JobStateQueued,
+	})
 	assert.NoError(t, err)
 
 	srv := New(st, nil, nil, &noopK8sJobClient{})
@@ -206,7 +212,7 @@ func TestJobCancel(t *testing.T) {
 			st, tearDown := store.NewTest(t)
 			defer tearDown()
 
-			err := st.CreateJob(&store.Job{JobID: jobID, State: tc.state, TenantID: fakeTenantID})
+			err := st.CreateJob(&store.Job{JobID: jobID, State: tc.state, TenantID: fakeTenantID, ProjectID: defaultProjectID})
 			assert.NoError(t, err)
 
 			srv := New(st, nil, nil, &noopK8sJobClient{})

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -19,6 +19,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const (
+	defaultProjectID = "default"
+)
+
 type fileGetClient interface {
 	GetFile(ctx context.Context, in *fv1.GetFileRequest, opts ...grpc.CallOption) (*fv1.File, error)
 }
@@ -110,7 +114,7 @@ func (s *S) extractUserInfoFromContext(ctx context.Context) (*auth.UserInfo, err
 	if !s.enableAuth {
 		return &auth.UserInfo{
 			OrganizationID:      "default",
-			ProjectID:           "default",
+			ProjectID:           defaultProjectID,
 			KubernetesNamespace: "default",
 		}, nil
 	}


### PR DESCRIPTION
Use project ID instead of tenant ID for visibiilty.