### PR TITLE
Pull Jupyter Notebook images from mirror.gcr.io

### DIFF
--- a/deployments/server/values.yaml
+++ b/deployments/server/values.yaml
@@ -31,8 +31,8 @@ debug:
 notebook:
   # TODO(aya): build own image and think the way to switch the driver version
   imageTypes:
-    jupyter-lab-base: cschranz/gpu-jupyter:v1.7_cuda-12.3_ubuntu-22.04_python-only
-    jupyter-lab-full: cschranz/gpu-jupyter:v1.7_cuda-12.3_ubuntu-22.04
+    jupyter-lab-base: mirror.gcr.io/cschranz/gpu-jupyter:v1.7_cuda-12.3_ubuntu-22.04_python-only
+    jupyter-lab-full: mirror.gcr.io/cschranz/gpu-jupyter:v1.7_cuda-12.3_ubuntu-22.04
 
 replicaCount: 1
 


### PR DESCRIPTION
This is to avoid hitting the docker pull rate limit. As mentioned in the TODO comment, would make sense to have the images in our registory eventually.