### PR TITLE
Set the job backoff limit to 0

### DIFF
--- a/dispatcher/internal/dispatcher/job_client.go
+++ b/dispatcher/internal/dispatcher/job_client.go
@@ -114,7 +114,9 @@ func (p *JobClient) jobSpec(jobProto *v1.Job, presult *PreProcessResult) (*batch
 		WithRestartPolicy(corev1.RestartPolicyNever)
 	jobSpec := batchv1apply.JobSpec().
 		WithTTLSecondsAfterFinished(int32(jobTTL.Seconds())).
-		WithBackoffLimit(3).
+		// Do not allow retries to simplify the failure handling.
+		// TODO(kenji): Revisit.
+		WithBackoffLimit(0).
 		WithTemplate(corev1apply.PodTemplateSpec().
 			WithSpec(podSpec))
 	return jobSpec, nil


### PR DESCRIPTION
To simplify the implementation. Before this change, the job's status could become 'failed' while a pod is still being recreated with retry.