### PR TITLE
Do nothing from convert-lora-to-ggml.py in fake-job

### DIFF
--- a/build/fake-job/convert-lora-to-ggml.py
+++ b/build/fake-job/convert-lora-to-ggml.py
@@ -1,3 +1,1 @@
-import os
-
-os.system("cp ./ggml-adapter-model.bin ./output/")
+# Do nothing


### PR DESCRIPTION
sft.py moves the file. We don't need to copy again.