### PR TITLE
Add a separate Helm value for ingress class name for notebooks

### DIFF
--- a/deployments/dispatcher/templates/configmap.yaml
+++ b/deployments/dispatcher/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
         key: {{ .Values.job.wandbApiKeySecret.key }}
     notebook:
       llmOperatorBaseUrl: {{ .Values.global.llmOperatorBaseUrl }}
-      ingressClassName: {{ .Values.global.ingress.ingressClassName }}
+      ingressClassName: {{ .Values.notebook.ingressClassName }}
     jobManagerServerWorkerServiceAddr: {{ .Values.jobManagerServerWorkerServiceAddr }}
     fileManagerServerWorkerServiceAddr: {{ .Values.fileManagerServerWorkerServiceAddr }}
     modelManagerServerWorkerServiceAddr: {{ .Values.modelManagerServerWorkerServiceAddr }}

--- a/deployments/dispatcher/values.yaml
+++ b/deployments/dispatcher/values.yaml
@@ -23,6 +23,7 @@ global:
       enable: false
 
 pollingInterval: 10s
+
 job:
   image: public.ecr.aws/v8n3t7y5/llm-operator/fine-tuning
   version: 0.130.0
@@ -31,6 +32,9 @@ job:
   wandbApiKeySecret:
     name:
     key:
+
+notebook:
+  ingressClassName:
 
 # The following default values work if model-manager-server runs in the same namespace.
 jobManagerServerWorkerServiceAddr: job-manager-server-worker-service-grpc:8082


### PR DESCRIPTION
This can be set to an internal kong, which is different from an externally-facing kong.