### PR TITLE
Introduce global.worker.controlPlaneAddr

### DIFF
--- a/deployments/dispatcher/templates/configmap.yaml
+++ b/deployments/dispatcher/templates/configmap.yaml
@@ -20,10 +20,10 @@ data:
       ingressClassName: {{ .Values.notebook.ingressClassName }}
       gatewayName: {{ .Values.notebook.gatewayName }}
       gatewayNamespace: {{ .Values.notebook.gatewayNamespace }}
-    clusterManagerServerWorkerServiceAddr: {{ .Values.clusterManagerServerWorkerServiceAddr }}
-    jobManagerServerWorkerServiceAddr: {{ .Values.jobManagerServerWorkerServiceAddr }}
-    fileManagerServerWorkerServiceAddr: {{ .Values.fileManagerServerWorkerServiceAddr }}
-    modelManagerServerWorkerServiceAddr: {{ .Values.modelManagerServerWorkerServiceAddr }}
+    clusterManagerServerWorkerServiceAddr: {{ .Values.global.worker.controlPlaneAddr | default .Values.clusterManagerServerWorkerServiceAddr }}
+    jobManagerServerWorkerServiceAddr: {{ .Values.global.worker.controlPlaneAddr | default .Values.jobManagerServerWorkerServiceAddr }}
+    fileManagerServerWorkerServiceAddr: {{ .Values.global.worker.controlPlaneAddr | default .Values.fileManagerServerWorkerServiceAddr }}
+    modelManagerServerWorkerServiceAddr: {{ .Values.global.worker.controlPlaneAddr | default .Values.modelManagerServerWorkerServiceAddr }}
     worker:
       tls:
         enable: {{ .Values.global.worker.tls.enable }}

--- a/deployments/dispatcher/values.yaml
+++ b/deployments/dispatcher/values.yaml
@@ -18,6 +18,8 @@ global:
       key:
     tls:
       enable: false
+    # If specified, use this as the address for accessing the control-plane services.
+    controlPlaneAddr: ""
 
 pollingInterval: 10s
 


### PR DESCRIPTION
Currently end users need to specify the following in their Helm charts when deploying a worker plane.

```
job-manager-dispatcher:
  clusterManagerServerWorkerServiceAddr: <control plane address>
  fileManagerServerWorkerServiceAddr: <control plane address>
  jobManagerServerWorkerServiceAddr: <control plane address>
  modelManagerServerWorkerServiceAddr: <control plane address>
```

This works, but it is redundant.

This commit introduces global.worker.controlPlaneAddr. If specified, this is used to specify the addresses of the all control plane servers.