### PR TITLE
Make llmOperatorBaseUrl in values.yaml non-global

### DIFF
--- a/deployments/dispatcher/templates/configmap.yaml
+++ b/deployments/dispatcher/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
         name: {{ .Values.job.wandbApiKeySecret.name }}
         key: {{ .Values.job.wandbApiKeySecret.key }}
     notebook:
-      llmOperatorBaseUrl: {{ .Values.global.llmOperatorBaseUrl }}
+      llmOperatorBaseUrl: {{ .Values.notebook.llmOperatorBaseUrl }}
       enablePvc: {{ .Values.notebook.enablePvc }}
       storageClassName: {{ .Values.notebook.storageClassName }}
       storageSize: {{ .Values.notebook.storageSize }}

--- a/deployments/dispatcher/values.yaml
+++ b/deployments/dispatcher/values.yaml
@@ -10,8 +10,6 @@ global:
     accessKeyIdKey:
     secretAccessKeyKey:
 
-  llmOperatorBaseUrl:
-
   worker:
     registrationKeySecret:
       name:
@@ -33,6 +31,7 @@ job:
     key:
 
 notebook:
+  llmOperatorBaseUrl
   enablePvc: false
   storageClassName: "standard"
   storageSize: "100Gi"


### PR DESCRIPTION
This is only used by job-manager-dispatcher.